### PR TITLE
fix Github CI clippy errors

### DIFF
--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -104,20 +104,20 @@ impl<'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'_, 'de, DE
     type Error = DecodeError;
 
     serde::serde_if_integer128! {
-        fn deserialize_i128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: serde::de::Visitor<'de>,
         {
-            visitor.visit_i128(Decode::decode(&mut self.de)?)
+            visitor.visit_i128(Decode::decode(&mut *self.de)?)
         }
     }
 
     serde::serde_if_integer128! {
-        fn deserialize_u128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: serde::de::Visitor<'de>,
         {
-            visitor.visit_u128(Decode::decode(&mut self.de)?)
+            visitor.visit_u128(Decode::decode(&mut *self.de)?)
         }
     }
 
@@ -132,133 +132,133 @@ impl<'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'_, 'de, DE
     }
 
     fn deserialize_bool<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_bool(Decode::decode(&mut self.de)?)
+        visitor.visit_bool(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i8<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i8(Decode::decode(&mut self.de)?)
+        visitor.visit_i8(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i16<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i16(Decode::decode(&mut self.de)?)
+        visitor.visit_i16(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i32<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i32(Decode::decode(&mut self.de)?)
+        visitor.visit_i32(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i64<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i64(Decode::decode(&mut self.de)?)
+        visitor.visit_i64(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u8<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u8(Decode::decode(&mut self.de)?)
+        visitor.visit_u8(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u16<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u16(Decode::decode(&mut self.de)?)
+        visitor.visit_u16(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u32<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u32(Decode::decode(&mut self.de)?)
+        visitor.visit_u32(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u64<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u64(Decode::decode(&mut self.de)?)
+        visitor.visit_u64(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_f32<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_f32(Decode::decode(&mut self.de)?)
+        visitor.visit_f32(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_f64<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_f64(Decode::decode(&mut self.de)?)
+        visitor.visit_f64(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_char<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_char(Decode::decode(&mut self.de)?)
+        visitor.visit_char(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_str<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        let str = <&'de str>::borrow_decode(&mut self.de)?;
+        let str = <&'de str>::borrow_decode(&mut *self.de)?;
         visitor.visit_borrowed_str(str)
     }
 
@@ -275,23 +275,23 @@ impl<'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'_, 'de, DE
 
     #[cfg(feature = "alloc")]
     fn deserialize_string<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_string(Decode::decode(&mut self.de)?)
+        visitor.visit_string(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_bytes<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        let bytes = <&'de [u8]>::borrow_decode(&mut self.de)?;
+        let bytes = <&'de [u8]>::borrow_decode(&mut *self.de)?;
         visitor.visit_borrowed_bytes(bytes)
     }
 
@@ -308,23 +308,23 @@ impl<'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'_, 'de, DE
 
     #[cfg(feature = "alloc")]
     fn deserialize_byte_buf<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_byte_buf(Decode::decode(&mut self.de)?)
+        visitor.visit_byte_buf(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_option<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        let variant = crate::de::decode_option_variant(&mut self.de, "Option<T>")?;
+        let variant = crate::de::decode_option_variant(&mut *self.de, "Option<T>")?;
         if variant.is_some() {
             visitor.visit_some(self)
         } else {
@@ -365,13 +365,13 @@ impl<'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'_, 'de, DE
     }
 
     fn deserialize_seq<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = usize::decode(&mut self.de)?;
+        let len = usize::decode(&mut *self.de)?;
         self.deserialize_tuple(len, visitor)
     }
 
@@ -499,7 +499,7 @@ impl<'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'_, 'de, DE
             }
         }
 
-        let len = usize::decode(&mut self.de)?;
+        let len = usize::decode(&mut *self.de)?;
 
         visitor.visit_map(Access {
             deserializer: &mut self,
@@ -563,13 +563,13 @@ impl<'de, DE: BorrowDecoder<'de>> EnumAccess<'de> for SerdeDecoder<'_, 'de, DE> 
     type Variant = Self;
 
     fn variant_seed<V>(
-        mut self,
+        self,
         seed: V,
     ) -> Result<(V::Value, Self::Variant), Self::Error>
     where
         V: DeserializeSeed<'de>,
     {
-        let idx = u32::decode(&mut self.de)?;
+        let idx = u32::decode(&mut *self.de)?;
         let de: serde::de::value::U32Deserializer<crate::error::DecodeError> =
             idx.into_deserializer();
         let val = seed.deserialize(de)?;

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -148,20 +148,20 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
     type Error = DecodeError;
 
     serde::serde_if_integer128! {
-        fn deserialize_i128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: serde::de::Visitor<'de>,
         {
-            visitor.visit_i128(Decode::decode(&mut self.de)?)
+            visitor.visit_i128(Decode::decode(&mut *self.de)?)
         }
     }
 
     serde::serde_if_integer128! {
-        fn deserialize_u128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: serde::de::Visitor<'de>,
         {
-            visitor.visit_u128(Decode::decode(&mut self.de)?)
+            visitor.visit_u128(Decode::decode(&mut *self.de)?)
         }
     }
 
@@ -176,134 +176,134 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
     }
 
     fn deserialize_bool<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_bool(Decode::decode(&mut self.de)?)
+        visitor.visit_bool(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i8<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i8(Decode::decode(&mut self.de)?)
+        visitor.visit_i8(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i16<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i16(Decode::decode(&mut self.de)?)
+        visitor.visit_i16(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i32<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i32(Decode::decode(&mut self.de)?)
+        visitor.visit_i32(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_i64<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_i64(Decode::decode(&mut self.de)?)
+        visitor.visit_i64(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u8<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u8(Decode::decode(&mut self.de)?)
+        visitor.visit_u8(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u16<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u16(Decode::decode(&mut self.de)?)
+        visitor.visit_u16(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u32<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u32(Decode::decode(&mut self.de)?)
+        visitor.visit_u32(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_u64<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u64(Decode::decode(&mut self.de)?)
+        visitor.visit_u64(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_f32<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_f32(Decode::decode(&mut self.de)?)
+        visitor.visit_f32(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_f64<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_f64(Decode::decode(&mut self.de)?)
+        visitor.visit_f64(Decode::decode(&mut *self.de)?)
     }
 
     fn deserialize_char<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_char(Decode::decode(&mut self.de)?)
+        visitor.visit_char(Decode::decode(&mut *self.de)?)
     }
 
     #[cfg(feature = "alloc")]
     fn deserialize_str<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_string(Decode::decode(&mut self.de)?)
+        visitor.visit_string(Decode::decode(&mut *self.de)?)
     }
 
     #[cfg(not(feature = "alloc"))]
@@ -319,13 +319,13 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
 
     #[cfg(feature = "alloc")]
     fn deserialize_string<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_string(Decode::decode(&mut self.de)?)
+        visitor.visit_string(Decode::decode(&mut *self.de)?)
     }
 
     #[cfg(not(feature = "alloc"))]
@@ -341,13 +341,13 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
 
     #[cfg(feature = "alloc")]
     fn deserialize_bytes<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_byte_buf(Decode::decode(&mut self.de)?)
+        visitor.visit_byte_buf(Decode::decode(&mut *self.de)?)
     }
 
     #[cfg(not(feature = "alloc"))]
@@ -363,13 +363,13 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
 
     #[cfg(feature = "alloc")]
     fn deserialize_byte_buf<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_byte_buf(Decode::decode(&mut self.de)?)
+        visitor.visit_byte_buf(Decode::decode(&mut *self.de)?)
     }
 
     #[cfg(not(feature = "alloc"))]
@@ -384,13 +384,13 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
     }
 
     fn deserialize_option<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        let variant = crate::de::decode_option_variant(&mut self.de, "Option<T>")?;
+        let variant = crate::de::decode_option_variant(&mut *self.de, "Option<T>")?;
         if variant.is_some() {
             visitor.visit_some(self)
         } else {
@@ -431,13 +431,13 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
     }
 
     fn deserialize_seq<V>(
-        mut self,
+        self,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = usize::decode(&mut self.de)?;
+        let len = usize::decode(&mut *self.de)?;
         self.deserialize_tuple(len, visitor)
     }
 
@@ -562,7 +562,7 @@ impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {
             }
         }
 
-        let len = usize::decode(&mut self.de)?;
+        let len = usize::decode(&mut *self.de)?;
 
         visitor.visit_map(Access {
             deserializer: &mut self,
@@ -626,13 +626,13 @@ impl<'de, DE: Decoder> EnumAccess<'de> for SerdeDecoder<'_, DE> {
     type Variant = Self;
 
     fn variant_seed<V>(
-        mut self,
+        self,
         seed: V,
     ) -> Result<(V::Value, Self::Variant), Self::Error>
     where
         V: DeserializeSeed<'de>,
     {
-        let idx = u32::decode(&mut self.de)?;
+        let idx = u32::decode(&mut *self.de)?;
         let de: serde::de::value::U32Deserializer<crate::error::DecodeError> =
             idx.into_deserializer();
         let val = seed.deserialize(de)?;

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -231,13 +231,13 @@ where
     }
 
     fn serialize_some<T>(
-        mut self,
+        self,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize + ?Sized,
     {
-        1u8.encode(&mut self.enc)?;
+        1u8.encode(&mut *self.enc)?;
         value.serialize(self)
     }
 
@@ -273,7 +273,7 @@ where
     }
 
     fn serialize_newtype_variant<T>(
-        mut self,
+        self,
         _name: &'static str,
         variant_index: u32,
         _variant: &'static str,
@@ -282,16 +282,16 @@ where
     where
         T: Serialize + ?Sized,
     {
-        variant_index.encode(&mut self.enc)?;
+        variant_index.encode(&mut *self.enc)?;
         value.serialize(self)
     }
 
     fn serialize_seq(
-        mut self,
+        self,
         len: Option<usize>,
     ) -> Result<Self::SerializeSeq, Self::Error> {
         let len = len.ok_or_else(|| SerdeEncodeError::SequenceMustHaveLength.into())?;
-        len.encode(&mut self.enc)?;
+        len.encode(&mut *self.enc)?;
         Ok(self)
     }
 
@@ -311,22 +311,22 @@ where
     }
 
     fn serialize_tuple_variant(
-        mut self,
+        self,
         _name: &'static str,
         variant_index: u32,
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        variant_index.encode(&mut self.enc)?;
+        variant_index.encode(&mut *self.enc)?;
         Ok(self)
     }
 
     fn serialize_map(
-        mut self,
+        self,
         len: Option<usize>,
     ) -> Result<Self::SerializeMap, Self::Error> {
         let len = len.ok_or_else(|| SerdeEncodeError::SequenceMustHaveLength.into())?;
-        len.encode(&mut self.enc)?;
+        len.encode(&mut *self.enc)?;
         Ok(self)
     }
 
@@ -339,13 +339,13 @@ where
     }
 
     fn serialize_struct_variant(
-        mut self,
+        self,
         _name: &'static str,
         variant_index: u32,
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        variant_index.encode(&mut self.enc)?;
+        variant_index.encode(&mut *self.enc)?;
         Ok(self)
     }
 


### PR DESCRIPTION
Fixes `clippy::mut_mut` errors across the Serde feature implementation that were exposed following a recent Rustup / Nightly Clippy update.

The updated Clippy version strictly checks double-mutable reference creations (`&mut &mut T`) when passing mutable fields to `Decode::decode` / `Encode::encode`.

### Files Modified
- `src/features/serde/de_borrowed.rs`: Reborrow `self.de` via `&mut *self.de`
- `src/features/serde/de_owned.rs`: Reborrow `self.de` via `&mut *self.de`
- `src/features/serde/ser.rs`: Reborrow mutable serializer references properly.