### PR TITLE
🧪 Add varint_decode_i16 tests

### DIFF
--- a/src/varint/decode_signed.rs
+++ b/src/varint/decode_signed.rs
@@ -115,14 +115,46 @@ fn test_decode_i16() {
         (&[0], &[0], 0),
         (&[4], &[4], 2),
         (&[3], &[3], -2),
-        (&[crate::varint::U16_BYTE, 0, 2], &[crate::varint::U16_BYTE, 2, 0], 256),
-        (&[crate::varint::U16_BYTE, 255, 1], &[crate::varint::U16_BYTE, 1, 255], -256),
-        (&[crate::varint::U16_BYTE, 0, 125], &[crate::varint::U16_BYTE, 125, 0], 16000),
-        (&[crate::varint::U16_BYTE, 255, 124], &[crate::varint::U16_BYTE, 124, 255], -16000),
-        (&[crate::varint::U16_BYTE, 252, 255], &[crate::varint::U16_BYTE, 255, 252], 32766),
-        (&[crate::varint::U16_BYTE, 254, 255], &[crate::varint::U16_BYTE, 255, 254], 32767),
-        (&[crate::varint::U16_BYTE, 253, 255], &[crate::varint::U16_BYTE, 255, 253], -32767),
-        (&[crate::varint::U16_BYTE, 255, 255], &[crate::varint::U16_BYTE, 255, 255], -32768),
+        (
+            &[crate::varint::U16_BYTE, 0, 2],
+            &[crate::varint::U16_BYTE, 2, 0],
+            256,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 255, 1],
+            &[crate::varint::U16_BYTE, 1, 255],
+            -256,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 0, 125],
+            &[crate::varint::U16_BYTE, 125, 0],
+            16000,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 255, 124],
+            &[crate::varint::U16_BYTE, 124, 255],
+            -16000,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 252, 255],
+            &[crate::varint::U16_BYTE, 255, 252],
+            32766,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 254, 255],
+            &[crate::varint::U16_BYTE, 255, 254],
+            32767,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 253, 255],
+            &[crate::varint::U16_BYTE, 255, 253],
+            -32767,
+        ),
+        (
+            &[crate::varint::U16_BYTE, 255, 255],
+            &[crate::varint::U16_BYTE, 255, 255],
+            -32768,
+        ),
     ];
 
     for &(slice_le, slice_be, expected) in cases {
@@ -157,8 +189,14 @@ fn test_decode_i16() {
                 found: IntegerType::I128,
             },
         ),
-        (&[crate::varint::U16_BYTE], DecodeError::UnexpectedEnd { additional: 2 }),
-        (&[crate::varint::U16_BYTE, 0], DecodeError::UnexpectedEnd { additional: 1 }),
+        (
+            &[crate::varint::U16_BYTE],
+            DecodeError::UnexpectedEnd { additional: 2 },
+        ),
+        (
+            &[crate::varint::U16_BYTE, 0],
+            DecodeError::UnexpectedEnd { additional: 1 },
+        ),
     ];
 
     for (slice, expected) in errors {

--- a/src/varint/decode_signed.rs
+++ b/src/varint/decode_signed.rs
@@ -108,3 +108,62 @@ pub fn varint_decode_isize<R: Reader>(
         | Err(e) => Err(e),
     }
 }
+
+#[test]
+fn test_decode_i16() {
+    let cases: &[(&[u8], &[u8], i16)] = &[
+        (&[0], &[0], 0),
+        (&[4], &[4], 2),
+        (&[3], &[3], -2),
+        (&[crate::varint::U16_BYTE, 0, 2], &[crate::varint::U16_BYTE, 2, 0], 256),
+        (&[crate::varint::U16_BYTE, 255, 1], &[crate::varint::U16_BYTE, 1, 255], -256),
+        (&[crate::varint::U16_BYTE, 0, 125], &[crate::varint::U16_BYTE, 125, 0], 16000),
+        (&[crate::varint::U16_BYTE, 255, 124], &[crate::varint::U16_BYTE, 124, 255], -16000),
+        (&[crate::varint::U16_BYTE, 252, 255], &[crate::varint::U16_BYTE, 255, 252], 32766),
+        (&[crate::varint::U16_BYTE, 254, 255], &[crate::varint::U16_BYTE, 255, 254], 32767),
+        (&[crate::varint::U16_BYTE, 253, 255], &[crate::varint::U16_BYTE, 255, 253], -32767),
+        (&[crate::varint::U16_BYTE, 255, 255], &[crate::varint::U16_BYTE, 255, 255], -32768),
+    ];
+
+    for &(slice_le, slice_be, expected) in cases {
+        let mut reader = crate::de::read::SliceReader::new(slice_le);
+        let found = varint_decode_i16(&mut reader, Endianness::Little).unwrap();
+        assert_eq!(expected, found);
+
+        let mut reader = crate::de::read::SliceReader::new(slice_be);
+        let found = varint_decode_i16(&mut reader, Endianness::Big).unwrap();
+        assert_eq!(expected, found);
+    }
+
+    let errors: &[(&[u8], DecodeError)] = &[
+        (
+            &[crate::varint::U32_BYTE],
+            DecodeError::InvalidIntegerType {
+                expected: IntegerType::I16,
+                found: IntegerType::I32,
+            },
+        ),
+        (
+            &[crate::varint::U64_BYTE],
+            DecodeError::InvalidIntegerType {
+                expected: IntegerType::I16,
+                found: IntegerType::I64,
+            },
+        ),
+        (
+            &[crate::varint::U128_BYTE],
+            DecodeError::InvalidIntegerType {
+                expected: IntegerType::I16,
+                found: IntegerType::I128,
+            },
+        ),
+        (&[crate::varint::U16_BYTE], DecodeError::UnexpectedEnd { additional: 2 }),
+        (&[crate::varint::U16_BYTE, 0], DecodeError::UnexpectedEnd { additional: 1 }),
+    ];
+
+    for (slice, expected) in errors {
+        let mut reader = crate::de::read::SliceReader::new(slice);
+        let found = varint_decode_i16(&mut reader, Endianness::Little).unwrap_err();
+        assert_eq!(std::format!("{expected:?}"), std::format!("{found:?}"));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for `varint_decode_i16` in `decode_signed.rs`
📊 **Coverage:** Covered boundary conditions (positive max, negative max, etc.) as well as zero and negative/positive normal numbers. Covered error conditions like unexpected end and invalid integer type decodings. Included both big and little endian modes.
✨ **Result:** Improved test coverage for signed integer decoding.

---
*PR created automatically by Jules for task [6548754917195442794](https://jules.google.com/task/6548754917195442794) started by @panayang*