### PR TITLE
⚡ perf: Optimize high concurrency test by wrapping payload in Arc

### DIFF
--- a/tests/high_concurrency.rs
+++ b/tests/high_concurrency.rs
@@ -4,6 +4,7 @@ use bincode_next::config;
 use bincode_next::decode_async;
 use futures_io::AsyncRead;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Instant;
@@ -16,7 +17,7 @@ struct BenchPayload {
 }
 
 struct PartialReader {
-    data: Vec<u8>,
+    data: Arc<Vec<u8>>,
     yields: usize,
     pos: usize,
 }
@@ -45,7 +46,7 @@ impl AsyncRead for PartialReader {
 }
 
 async fn run_worker(
-    encoded: Vec<u8>
+    encoded: Arc<Vec<u8>>
 ) -> core::result::Result<(), bincode_next::error::DecodeError> {
     let reader = PartialReader {
         data: encoded,
@@ -63,7 +64,7 @@ async fn test_high_concurrency() {
         id: 123456789,
         data: "High concurrency testing payload".to_string(),
     };
-    let encoded = bincode_next::encode_to_vec(&payload, config::standard()).unwrap();
+    let encoded = Arc::new(bincode_next::encode_to_vec(&payload, config::standard()).unwrap());
 
     let total_tasks: usize = 5_000_000;
     let batch_size: usize = 50_000;
@@ -113,7 +114,7 @@ async fn test_high_concurrency_no_batching() {
         id: 123456789,
         data: "High concurrency testing payload".to_string(),
     };
-    let encoded = bincode_next::encode_to_vec(&payload, config::standard()).unwrap();
+    let encoded = Arc::new(bincode_next::encode_to_vec(&payload, config::standard()).unwrap());
 
     let concurrency = 5_000_000;
     println!(


### PR DESCRIPTION
💡 **What:** 
Replaced `Vec<u8>` with `Arc<Vec<u8>>` for the `encoded` payload in `tests/high_concurrency.rs`. This involved updating `PartialReader`'s `data` field and `run_worker`'s argument type, along with wrapping the serialized payload in an `Arc` inside both test functions.

🎯 **Why:** 
The high concurrency test was performing a deep clone of the `encoded` payload vector inside the task spawning loop (`encoded.clone()`). In a tight loop spawning 5,000,000 tasks, this leads to massive, expensive memory allocations that drastically affect performance. Wrapping the payload in an `Arc` (Atomic Reference Count) ensures only the reference count is incremented upon cloning, avoiding deep copies of the byte array and saving significant CPU and memory allocation overhead.

📊 **Measured Improvement:** 
Running `cargo test --release --test high_concurrency` before and after the change showed significant performance improvements:

**Baseline:**
* Batching: Processed 5000000 tasks in 8.17s (612166.94 tasks/sec)
* No Batching: Processed 5000000 tasks in 23.58s (212024.57 tasks/sec)

**After Optimization:**
* Batching: Processed 5000000 tasks in 5.67s (881996.51 tasks/sec) -> **~44% faster**
* No Batching: Processed 5000000 tasks in 7.85s (637342.51 tasks/sec) -> **~200% faster**

---
*PR created automatically by Jules for task [13273604940859237615](https://jules.google.com/task/13273604940859237615) started by @panayang*